### PR TITLE
Postcss support (and deprecate autoprefixer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 A sensible distribution of [Sass][] for [Metalsmith][].
 
-- combines [metalsmith-sass][] and [metalsmith-postcss][]
-- uses [postcss-cssnext][] when available
-- compresses output on production
-- adds source maps in development mode
+- uses [metalsmith-sass][] with environment-specific defaults
+	- compresses output on production
+	- adds source maps in development mode
+- uses [metalsmith-postcss][] for optional postcss plugins to be used after Sass
+- uses [postcss-cssnext][] when available (for vendor prefix polyfills and more)
 - ignores sass partials (`_*.sass`)
 
 [![Status](https://travis-ci.org/rstacruz/metalsmith-sense-sass.svg?branch=master)](https://travis-ci.org/rstacruz/metalsmith-sense-sass "See test builds")

--- a/README.md
+++ b/README.md
@@ -10,17 +10,25 @@ A sensible distribution of [Sass][] for [Metalsmith][].
 
 [![Status](https://travis-ci.org/rstacruz/metalsmith-sense-sass.svg?branch=master)](https://travis-ci.org/rstacruz/metalsmith-sense-sass "See test builds")
 
-Available options:
+## Options
 
-- `sass` - options to pass to metalsmith-sass.
-- `postcss` - plugins to load for postcss. This is in the format of a key/value object, where keys are string package names, and the values are options to be passed to each plugin.
+```js
+require('metalsmith-sense-sass')(options)
+```
 
-Environment variables:
+#### Available options:
 
-- `NODE_ENV` (environment variable) - set to `production` to enable compression and disable source maps.
+- `sass` *(Object)* — Options to pass to metalsmith-sass. See [node-sass][] for a list of available options.
+
+- `postcss` *(Object)* — List of plugins to load for postcss. This is in the format of a key/value object, where keys are string package names, and the values are options to be passed to each plugin.
+
+#### Environment variables:
+
+- `NODE_ENV` *(environment variable)* — set to `production` to enable compression and disable source maps.
 
 [Metalsmith]: http://www.metalsmith.io/
 [Sass]: http://sass-lang.com/
+[node-sass]: https://github.com/sass/node-sass#options
 [metalsmith-sass]: https://www.npmjs.com/package/metalsmith-sass
 [metalsmith-postcss]: https://www.npmjs.com/package/metalsmith-postcss
 
@@ -32,24 +40,24 @@ It's recommended to use this with [postcss-cssnext][], which will take care of v
 npm install --save metalsmith-sense-sass postcss-cssnext
 ```
 
-When using `metalsmith.json`:
+* When using `metalsmith.json`:
 
-```json
-{
-  "plugins": {
-    "metalsmith-sense-sass": {}
-  }
-}
-```
+	```json
+	{
+	  "plugins": {
+	    "metalsmith-sense-sass": {}
+	  }
+	}
+	```
 
-When using `metalsmith.js`:
+* When using `metalsmith.js`:
 
-```js
-var ms = new Metalsmith(__dirname)
-  .source('src')
-  .destination('public')
-  .use(require('metalsmith-sense-sass')())
-```
+	```js
+	var ms = new Metalsmith(__dirname)
+	  .source('src')
+	  .destination('public')
+	  .use(require('metalsmith-sense-sass')())
+	```
 
 [postcss-cssnext]: https://www.npmjs.com/package/postcss-cssnext
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 A sensible distribution of [Sass][] for [Metalsmith][].
 
-- combines [metalsmith-sass][] and [metalsmith-autoprefixer][]
+- combines [metalsmith-sass][] and [metalsmith-postcss][]
+- uses [postcss-cssnext][] when available
 - compresses output on production
 - adds source maps in development mode
 - ignores sass partials (`_*.sass`)
@@ -12,7 +13,7 @@ A sensible distribution of [Sass][] for [Metalsmith][].
 Available options:
 
 - `sass` - options to pass to metalsmith-sass.
-- `autoprefixer` - options to pass to metalsmith-autoprefixer.
+- `postcss` - plugins to load for postcss. This is in the format of a key/value object, where keys are string package names, and the values are options to be passed to each plugin.
 
 Environment variables:
 
@@ -21,9 +22,15 @@ Environment variables:
 [Metalsmith]: http://www.metalsmith.io/
 [Sass]: http://sass-lang.com/
 [metalsmith-sass]: https://www.npmjs.com/package/metalsmith-sass
-[metalsmith-autoprefixer]: https://www.npmjs.com/package/metalsmith-autoprefixer
+[metalsmith-postcss]: https://www.npmjs.com/package/metalsmith-postcss
 
 ## Usage
+
+It's recommended to use this with [postcss-cssnext][], which will take care of vendor prefixing.
+
+```sh
+npm install --save metalsmith-sense-sass postcss-cssnext
+```
 
 When using `metalsmith.json`:
 
@@ -42,6 +49,26 @@ var ms = new Metalsmith(__dirname)
   .source('src')
   .destination('public')
   .use(require('metalsmith-sense-sass')())
+```
+
+[postcss-cssnext]: https://www.npmjs.com/package/postcss-cssnext
+
+## Using without postcss-cssnext
+
+If `postcss-cssnext` is not available, it won't be used.
+
+## Using with other postCSS plugins
+
+```js
+var ms = new Metalsmith(__dirname)
+  .source('src')
+  .destination('public')
+  .use(require('metalsmith-sense-sass')({
+    postcss: {
+      'postcss-import': {},
+      'postcss-cssnext': {}
+    }
+  }))
 ```
 
 ## Also see

--- a/README.md
+++ b/README.md
@@ -55,9 +55,41 @@ var ms = new Metalsmith(__dirname)
 
 ## Using without postcss-cssnext
 
-If `postcss-cssnext` is not available, it won't be used.
+If `postcss-cssnext` is not available, it won't be used. If it's available and you *don't* want to use it, pass `{}` to the `postcss` options.
+
+```json
+{
+  "plugins": {
+    "metalsmith-sense-sass": {
+      "postcss": {}
+    }
+  }
+}
+```
+
+```js
+var ms = new Metalsmith(__dirname)
+  .source('src')
+  .destination('public')
+  .use(require('metalsmith-sense-sass')({
+    postcss: {}
+  }))
+```
 
 ## Using with other postCSS plugins
+
+```json
+{
+  "plugins": {
+    "metalsmith-sense-sass": {
+      "postcss": {
+        "postcss-import": {},
+        "postcss-cssnext": {}
+      }
+    }
+  }
+}
+```
 
 ```js
 var ms = new Metalsmith(__dirname)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # metalsmith-sense-sass
 
-A sensible distribution of [Sass][] for [Metalsmith][].
+> A sensible distribution of [Sass][] for [Metalsmith][].
 
 - uses [metalsmith-sass][] with environment-specific defaults
 	- compresses output on production
@@ -63,6 +63,10 @@ npm install --save metalsmith-sense-sass postcss-cssnext
 [postcss-cssnext]: https://www.npmjs.com/package/postcss-cssnext
 
 For other installation options (eg, using other postcss plugins), see [Installation](docs/installation.md).
+
+## Upgrading from 1.x
+
+metalsmith-sense-sass 1.x uses autoprefixer by default, which 2.x doesn't anymore. To upgrade and keep the old behavior, simply install [postcss-cssnext][] in your project—cssnext includes autoprefixer, and metalsmith-sense-sass will automatically use cssnext if it's available.
 
 ## Also see
 

--- a/README.md
+++ b/README.md
@@ -53,55 +53,7 @@ var ms = new Metalsmith(__dirname)
 
 [postcss-cssnext]: https://www.npmjs.com/package/postcss-cssnext
 
-## Using without postcss-cssnext
-
-If `postcss-cssnext` is not available, it won't be used. If it's available and you *don't* want to use it, pass `{}` to the `postcss` options.
-
-```json
-{
-  "plugins": {
-    "metalsmith-sense-sass": {
-      "postcss": {}
-    }
-  }
-}
-```
-
-```js
-var ms = new Metalsmith(__dirname)
-  .source('src')
-  .destination('public')
-  .use(require('metalsmith-sense-sass')({
-    postcss: {}
-  }))
-```
-
-## Using with other postCSS plugins
-
-```json
-{
-  "plugins": {
-    "metalsmith-sense-sass": {
-      "postcss": {
-        "postcss-import": {},
-        "postcss-cssnext": {}
-      }
-    }
-  }
-}
-```
-
-```js
-var ms = new Metalsmith(__dirname)
-  .source('src')
-  .destination('public')
-  .use(require('metalsmith-sense-sass')({
-    postcss: {
-      'postcss-import': {},
-      'postcss-cssnext': {}
-    }
-  }))
-```
+For other installation options (eg, using other postcss plugins), see [Installation](docs/installation.md).
 
 ## Also see
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,51 @@
+# Installation
+
+## Using without postcss-cssnext
+
+If `postcss-cssnext` is not available, it won't be used. If it's available and you *don't* want to use it, pass `{}` to the `postcss` options.
+
+```json
+{
+  "plugins": {
+    "metalsmith-sense-sass": {
+      "postcss": {}
+    }
+  }
+}
+```
+
+```js
+var ms = new Metalsmith(__dirname)
+  .source('src')
+  .destination('public')
+  .use(require('metalsmith-sense-sass')({
+    postcss: {}
+  }))
+```
+
+## Using with other postCSS plugins
+
+```json
+{
+  "plugins": {
+    "metalsmith-sense-sass": {
+      "postcss": {
+        "postcss-import": {},
+        "postcss-cssnext": {}
+      }
+    }
+  }
+}
+```
+
+```js
+var ms = new Metalsmith(__dirname)
+  .source('src')
+  .destination('public')
+  .use(require('metalsmith-sense-sass')({
+    postcss: {
+      'postcss-import': {},
+      'postcss-cssnext': {}
+    }
+  }))
+```

--- a/fixtures/basic/metalsmith.js
+++ b/fixtures/basic/metalsmith.js
@@ -1,0 +1,12 @@
+var ms = require('metalsmith')(__dirname)
+  .source('./src')
+  .destination('./public')
+  .use(require('../../index')())
+
+if (module.parent) {
+  module.exports = ms
+} else {
+  ms.build(function (err) {
+    if (err) throw err
+  })
+}

--- a/fixtures/sass_glob/metalsmith.js
+++ b/fixtures/sass_glob/metalsmith.js
@@ -1,0 +1,12 @@
+var ms = require('metalsmith')(__dirname)
+  .source('./src')
+  .destination('./public')
+  .use(require('../../index')())
+
+if (module.parent) {
+  module.exports = ms
+} else {
+  ms.build(function (err) {
+    if (err) throw err
+  })
+}

--- a/fixtures/sass_glob/src/base/_div.scss
+++ b/fixtures/sass_glob/src/base/_div.scss
@@ -1,0 +1,1 @@
+div { color: blue; }

--- a/fixtures/sass_glob/src/hello.sass
+++ b/fixtures/sass_glob/src/hello.sass
@@ -1,0 +1,1 @@
+@import './base/*'

--- a/fixtures/sass_import/metalsmith.js
+++ b/fixtures/sass_import/metalsmith.js
@@ -1,0 +1,12 @@
+var ms = require('metalsmith')(__dirname)
+  .source('./src')
+  .destination('./public')
+  .use(require('../../index')())
+
+if (module.parent) {
+  module.exports = ms
+} else {
+  ms.build(function (err) {
+    if (err) throw err
+  })
+}

--- a/fixtures/sass_import/src/hello.sass
+++ b/fixtures/sass_import/src/hello.sass
@@ -1,0 +1,1 @@
+@import 'normalize.css/normalize'

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (options) {
     ware()
       .use(require('metalsmith-ignore')([ '**/_*.{scss,sass}' ]))
       .use(require('metalsmith-sass')(options.sass))
-      .use(require('metalsmith-postcss')(toPostcss(options.postcss)))
+      .use(require('metalsmith-postcss')(options.postcss))
       .run(files, ms, done)
   }
 }
@@ -24,41 +24,21 @@ function sassDefaults () {
     return {
       outputStyle: 'expanded',
       sourceMapEmbed: true,
-      sourcemapContents: true
+      sourcemapContents: true,
+      importer: require('node-sass-import')
     }
   } else {
     return {
       outputStyle: 'compressed',
-      sourceMap: false
+      sourceMap: false,
+      importer: require('node-sass-import')
     }
   }
 }
 
-/*
- * Private: returns an array of postcss plugins.
- *
- *     toPostcss({
- *       'postcss-nested': {},
- *       'postcss-pseudoelements': {}
- *     })
- *
- *     // same as:
- *     [
- *       require('postcss-nested')({}),
- *       require('postcss-pseudoelements')({})
- *     ]
- */
-
-function toPostcss (plugins) {
-  return Object.keys(plugins).map(function (plugin) {
-    return require(plugin)(plugins[plugin])
-  })
-}
-
 function postcssDefaults () {
   try {
-    require.resolve('postcss-cssnext')
-    return { 'postcss-cssnext': {} }
+    return { plugins: { 'postcss-cssnext': {} } }
   } catch (e) {
     return {}
   }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var assign = require('object-assign')
 module.exports = function (options) {
   if (!options) options = {}
   options.sass = assign({}, sassDefaults(), options.sass || {})
-  options.postcss = assign({}, postcssDefaults(), options.postcss || {})
+  options.postcss = options.postcss || {}
 
   return function (files, ms, done) {
     ware()
@@ -53,8 +53,4 @@ function toPostcss (plugins) {
   return Object.keys(plugins).map(function (plugin) {
     return require(plugin)(plugins[plugin])
   })
-}
-
-function postcssDefaults () {
-  return { 'postcss-cssnext': {} }
 }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var assign = require('object-assign')
 module.exports = function (options) {
   if (!options) options = {}
   options.sass = assign({}, sassDefaults(), options.sass || {})
-  options.postcss = options.postcss || {}
+  options.postcss = options.postcss || postcssDefaults()
 
   return function (files, ms, done) {
     ware()
@@ -53,4 +53,13 @@ function toPostcss (plugins) {
   return Object.keys(plugins).map(function (plugin) {
     return require(plugin)(plugins[plugin])
   })
+}
+
+function postcssDefaults () {
+  try {
+    require.resolve('postcss-cssnext')
+    return { 'postcss-cssnext': {} }
+  } catch (e) {
+    return {}
+  }
 }

--- a/index.js
+++ b/index.js
@@ -4,12 +4,13 @@ var assign = require('object-assign')
 module.exports = function (options) {
   if (!options) options = {}
   options.sass = assign({}, sassDefaults(), options.sass || {})
+  options.postcss = assign({}, postcssDefaults(), options.postcss || {})
 
   return function (files, ms, done) {
     ware()
       .use(require('metalsmith-ignore')([ '**/_*.{scss,sass}' ]))
       .use(require('metalsmith-sass')(options.sass))
-      .use(require('metalsmith-autoprefixer')(options.autoprefixer))
+      .use(require('metalsmith-postcss')(toPostcss(options.postcss)))
       .run(files, ms, done)
   }
 }
@@ -31,4 +32,29 @@ function sassDefaults () {
       sourceMap: false
     }
   }
+}
+
+/*
+ * Private: returns an array of postcss plugins.
+ *
+ *     toPostcss({
+ *       'postcss-nested': {},
+ *       'postcss-pseudoelements': {}
+ *     })
+ *
+ *     // same as:
+ *     [
+ *       require('postcss-nested')({}),
+ *       require('postcss-pseudoelements')({})
+ *     ]
+ */
+
+function toPostcss (plugins) {
+  return Object.keys(plugins).map(function (plugin) {
+    return require(plugin)(plugins[plugin])
+  })
+}
+
+function postcssDefaults () {
+  return { 'postcss-cssnext': {} }
 }

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
   "dependencies": {
     "metalsmith-autoprefixer": "1.1.0",
     "metalsmith-ignore": "0.1.2",
+    "metalsmith-postcss": "3.1.0",
     "metalsmith-sass": "1.3.0",
     "object-assign": "4.0.1",
     "ware": "1.3.0"
   },
   "devDependencies": {
     "metalsmith": "2.1.0",
+    "postcss-cssnext": "2.4.0",
     "tape": "4.4.0"
   },
   "homepage": "https://github.com/rstacruz/metalsmith-sense-sass#readme",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "url": "https://github.com/rstacruz/metalsmith-sense-sass/issues"
   },
   "dependencies": {
-    "metalsmith-autoprefixer": "1.1.0",
     "metalsmith-ignore": "0.1.2",
     "metalsmith-postcss": "3.1.0",
     "metalsmith-sass": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -8,15 +8,17 @@
   },
   "dependencies": {
     "metalsmith-ignore": "0.1.2",
-    "metalsmith-postcss": "3.1.0",
+    "metalsmith-postcss": "4.0.0",
     "metalsmith-sass": "1.3.0",
-    "object-assign": "4.0.1",
+    "node-sass-import": "github:rstacruz/node-sass-import#patch-1",
+    "object-assign": "4.1.0",
+    "postcss-cssnext": "2.7.0",
     "ware": "1.3.0"
   },
   "devDependencies": {
-    "metalsmith": "2.1.0",
-    "postcss-cssnext": "2.4.0",
-    "tape": "4.4.0"
+    "metalsmith": "2.2.0",
+    "normalize.css": "4.2.0",
+    "tape": "4.6.0"
   },
   "homepage": "https://github.com/rstacruz/metalsmith-sense-sass#readme",
   "keywords": [

--- a/test.js
+++ b/test.js
@@ -65,6 +65,22 @@ test('sass import', function (t) {
   })
 })
 
+test('glob import', function (t) {
+  var ms = new Metalsmith('fixtures/sass_glob')
+    .source('src')
+    .destination('public')
+    .use(sense())
+
+  ms.build(function (err) {
+    if (err) t.fail(err)
+    var data = read(ms.path('public/hello.css'))
+
+    t.ok(data.indexOf('div') > -1,
+      'works')
+
+    t.end()
+  })
+})
 
 function read (file) {
   return require('fs').readFileSync(file, 'utf-8')

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ test('metalsmith-sense-sass (development)', function (t) {
   var ms = new Metalsmith('fixtures/basic')
     .source('src')
     .destination('public')
-    .use(sense({ postcss: { 'postcss-cssnext': {} } }))
+    .use(sense())
 
   ms.build(function (err) {
     if (err) t.fail(err)
@@ -32,7 +32,7 @@ test('metalsmith-sense-sass (production)', function (t) {
   var ms = new Metalsmith('fixtures/basic')
     .source('src')
     .destination('public')
-    .use(sense({ postcss: { 'postcss-cssnext': {} } }))
+    .use(sense())
 
   ms.build(function (err) {
     if (err) t.fail(err)

--- a/test.js
+++ b/test.js
@@ -48,6 +48,24 @@ test('metalsmith-sense-sass (production)', function (t) {
   })
 })
 
+test('sass import', function (t) {
+  var ms = new Metalsmith('fixtures/sass_import')
+    .source('src')
+    .destination('public')
+    .use(sense())
+
+  ms.build(function (err) {
+    if (err) t.fail(err)
+    var data = read(ms.path('public/hello.css'))
+
+    t.ok(data.indexOf('font-family') > -1,
+      'normalize.css enabled')
+
+    t.end()
+  })
+})
+
+
 function read (file) {
   return require('fs').readFileSync(file, 'utf-8')
 }

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ test('metalsmith-sense-sass (development)', function (t) {
   var ms = new Metalsmith('fixtures/basic')
     .source('src')
     .destination('public')
-    .use(sense())
+    .use(sense({ postcss: { 'postcss-cssnext': {} } }))
 
   ms.build(function (err) {
     if (err) t.fail(err)
@@ -32,7 +32,7 @@ test('metalsmith-sense-sass (production)', function (t) {
   var ms = new Metalsmith('fixtures/basic')
     .source('src')
     .destination('public')
-    .use(sense())
+    .use(sense({ postcss: { 'postcss-cssnext': {} } }))
 
   ms.build(function (err) {
     if (err) t.fail(err)


### PR DESCRIPTION
In retrospect, it's silly to assume autoprefixer, because there are many interesting alternatives. So here's a feature to allow you to use your own postcss plugins.

Also, if `postcss-cssnext` is available, it'll automatically be used—this makes it easy to maintain compatibility with metalsmith-sense-sass 1.x. (cssnext includes autoprefixer.)
